### PR TITLE
build(deps): pin minitest to ~> 5.25

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,4 +56,10 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+
+  # minitest 6 is not yet compatible with Rails' test runner: it breaks
+  # Rails::TestUnit::Runner on both 8.0 (ArgumentError in line_filtering.rb)
+  # and 8.1 (LoadError on the test:system pseudo task). Unpin once Rails
+  # supports minitest 6.
+  gem "minitest", "~> 5.25"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -350,6 +350,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   kamal
+  minitest (~> 5.25)
   propshaft
   puma (>= 5.0)
   rails (~> 8.0.1)


### PR DESCRIPTION
## 背景

open な Dependabot PR 9 件のうち 7 件が `test` job で失敗していた。原因は個々の gem ではなく、**Dependabot が推移的に minitest を 5.25.5 → 6.0.6 へ巻き込んでいた**こと。lock に minitest 6.0.6 が入った PR だけが落ち、入っていない #47 / #48 は pass しており相関は完全だった。

| PR | lock の minitest | test |
|---|---|---|
| #37, #41, #42, #43, #44, #45, #46 | 5.25.5 → **6.0.6** | ❌ |
| #47 (bootsnap), #48 (debug) | 変更なし | ✅ |

## エラーは 2 種類、根は同じ

minitest 6 が Rails の test runner と非互換で、`bin/rails test test:system` が起動時に落ちる。**Rails 8.0 / 8.1 の両方**で発生する（8.1 固有ではない）。

**Rails 8.0.2（#37, #41, #42, #43, #44, #45）**

```
railties-8.0.2/lib/rails/test_unit/line_filtering.rb:7:in 'run':
  wrong number of arguments (given 3, expected 1..2) (ArgumentError)
  from minitest-6.0.6/lib/minitest.rb:473:in 'block (2 levels) in Minitest::Runnable.run_suite'
```

minitest 6 で `Runnable.run` の呼び出し規約が引数 3 個に変わり、railties 側の override（1..2）と signature が合わない。

**Rails 8.1.3（#46）**

```
cannot load such file -- .../chord-expression-rails/test:system (LoadError)
  from railties-8.1.3/lib/rails/test_unit/runner.rb:71:in 'block in load_tests'
  from railties-8.1.3/lib/minitest/rails_plugin.rb:147
  from minitest-6.0.6/lib/minitest.rb:254:in 'block in process_args'
```

`test:system` という疑似タスク名が特別扱いされず、通常のファイルパスとして require されている。

## 変更内容

`Gemfile` にピン留め（+ 理由コメント）、`Gemfile.lock` は `DEPENDENCIES` に 1 行追加のみ。minitest 5.25.5 は既に specs にあるためバージョン変動はなし。

## 影響と確認事項

- rubygems 上の minitest 最新は 6.0.6（2026-05-01）で、以降のリリースはなく上流修正はまだ出ていない。
- activesupport の制約は Rails 8.1.3 でも `minitest (>= 5.1)` のままなので、**このピン留めは Rails 8.1 への更新を阻害しない**（#46 も通せる）。
- lock の整合性は `BUNDLED WITH` と同じ bundler 2.6.3 で再解決して確認済み。
- minitest が直接依存になるため、今後 Dependabot が「Gemfile の制約自体を `~> 6.0` に上げる PR」を出す可能性がある。抑制が必要なら `.github/dependabot.yml` に ignore を別途追加する。

Rails が minitest 6 に対応したらこのピンを外す。マージ後、失敗中の 7 PR を rebase して通す予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)